### PR TITLE
Usability Update for Memory Editor

### DIFF
--- a/firmware/beastos/monitor.asm
+++ b/firmware/beastos/monitor.asm
@@ -561,7 +561,7 @@ _exec_done          PUSH    AF
                     CALL    hex_out
                     CALL    m_print_inline
                     .DB     ESCAPE_CHAR, "K", 0
-                    JP      bios_conin
+                    CALL    bios_conin ;pause for a key, then return to memory edit at the execution location
 
 
 edit_memory         XOR     A

--- a/firmware/io.asm
+++ b/firmware/io.asm
@@ -340,8 +340,8 @@ KEY_CTRL_BIT    .EQU    2
 KEY_REPEAT_DELAY .EQU   40
 KEY_REPEAT_AFTER .EQU   KEY_REPEAT_DELAY+7
 
-keyboard        .DB    "vcxz", KEY_SHIFT, 0
-                .DB    "gfdsa", KEY_CTRL
+keyboard        .DB    "vcxz", KEY_CTRL, 0
+                .DB    "gfdsa", KEY_SHIFT
                 .DB    "trewq", KEY_DOWN
                 .DB    "54321", KEY_UP  
                 .DB    "67890", KEY_BACKSPACE


### PR DESCRIPTION
This allows you to return to the point of execution, instead of the main clock menu each time you execute code.

This fixes issue #6